### PR TITLE
Install gcloud step added

### DIFF
--- a/beginners/gcp/README.md
+++ b/beginners/gcp/README.md
@@ -15,6 +15,37 @@ In order to avoid explicitly using the GCP service key, we are going to use GOOG
 3. If you have not created a service account and a service key then follow below steps
 
    - Install gcloud cli
+
+   The gcloud cli is a part of [Google Cloud SDK](https://cloud.google.com/sdk/docs). We must download and install the SDK on your system and initialize it before you can use the gcloud command-line tool. 
+   Note: You can follow the install script given in the Google Cloud SDK documentation.
+
+   Google Cloud SDK Quickstart script for CentOS,
+
+   ```
+   sudo tee -a /etc/yum.repos.d/google-cloud-sdk.repo << EOM
+   [google-cloud-sdk]
+   name=Google Cloud SDK
+   baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
+   enabled=1
+   gpgcheck=1
+   repo_gpgcheck=1
+   gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
+          https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+   EOM
+   ```
+
+   Then install Google cloud SDK using command,
+
+   ```
+   yum install google-cloud-sdk
+   ```
+
+   Once the the SDK is installed, run gcloud init to initialize the SDK,
+
+   ```
+   gcloud init
+   ```
+
    - Run the following scripts
 
    ````bash


### PR DESCRIPTION
Added Google Cloud SDK installation step by adding how to install it on CentOS
Reference URL attached: https://cloud.google.com/sdk/docs

Thank you.