### PR TITLE
backend: Added remote statefile backend for AWS (i.e. s3)

### DIFF
--- a/beginners/aws/backend.tf
+++ b/beginners/aws/backend.tf
@@ -1,0 +1,7 @@
+terraform{
+backend "s3" {
+bucket = "s3bucketName" // s3 bucket name created from AWS console
+key = "terraform.tfstate" // terraform state file
+region = "" // provide s3 bucket region
+}
+}


### PR DESCRIPTION
To store terraform statefile at remote location, terraform provide backends (i.e s3, gcs, azurerm..etc).

Here i have use s3 bucket to store aws infrastructure statefile from local to remote.

Steps to create:

1. Create s3 bucket from aws using console or aws cli
2. Add s3 bucket name and statefile name in backend.tf file  (i.e. bucket and key)


Happy Terraforming!